### PR TITLE
Fix bug from lightmode, add failed to save check by size check

### DIFF
--- a/cameras/pi-zero/large-display/software/camera/camera.py
+++ b/cameras/pi-zero/large-display/software/camera/camera.py
@@ -182,6 +182,11 @@ class Camera:
     Thread(target=self.live_preview).start()
     self.main.processing = False # this is everywhere... sucks
 
+  def photo_saved(path):
+    file_info = os.stat(path)
+
+    return file_info.st_size > 0
+
   def take_photo(self):
     self.reset_preview_time()
     img_path = self.img_base_path + str(time.time()).split(".")[0] + ".jpg"
@@ -189,6 +194,8 @@ class Camera:
     self.picam2.capture_file(img_path)
     time.sleep(0.15) # delay may help to save?
     self.change_mode(self.last_mode)
+
+    return img_path
 
   def timelapse(self):
     while (self.timelapse_active):
@@ -239,9 +246,14 @@ class Camera:
       time.sleep(0.3) # allow live_preview thread to pick this up/stop painting oled
       self.display.clear_screen()
       self.display.draw_text("Taking photo...")
-      self.take_photo()
+      photo_path = self.take_photo()
       self.display.clear_screen()
-      self.display.draw_text("Photo captured")
+
+      if (self.photo_saved(photo_path)):
+        self.display.draw_text("Photo captured")
+      else:
+        self.display.draw_text("Photo failed") # lol get rekt
+
       self.toggle_live_preview(True)
       time.sleep(0.3)
     

--- a/cameras/pi-zero/large-display/software/camera/camera.py
+++ b/cameras/pi-zero/large-display/software/camera/camera.py
@@ -182,7 +182,7 @@ class Camera:
     Thread(target=self.live_preview).start()
     self.main.processing = False # this is everywhere... sucks
 
-  def photo_saved(path):
+  def photo_saved(self, path):
     file_info = os.stat(path)
 
     return file_info.st_size > 0

--- a/cameras/pi-zero/large-display/software/display/display.py
+++ b/cameras/pi-zero/large-display/software/display/display.py
@@ -257,7 +257,7 @@ class Display:
     draw.text((22, 72), "Yes", fill = "BLUE" if is_charged else "BLACK", font = small_font)
     draw.text((60, 72), "No", fill = "BLACK" if is_charged else "BLUE", font = small_font) # default option
 
-    self.self.ShowImage(self.match_lcd(image))
+    self.disp.ShowImage(self.match_lcd(image))
 
   def draw_active_telemetry(self):
     image = self.get_settings_img()
@@ -300,7 +300,7 @@ class Display:
       draw.text((5, 66), "gyro y: " + str(gyro[1])[0:8], fill = "BLACK", font = small_font)
       draw.text((5, 76), "gyro z: " + str(gyro[2])[0:8], fill = "BLACK", font = small_font)
 
-      self.self.ShowImage(self.match_lcd(image))
+      self.disp.ShowImage(self.match_lcd(image))
     
   # special page, it is not static
   # has active loop to display data


### PR DESCRIPTION
So I recently did a battery profile and it ran a path of logic that wasn't tested before... which was broken, just dumb batch replace

I also added a file save check which uses `os.stat`... I tried to make this fail so I could see it working

It seems it is a time thing (this process adds more delay, ensures photo saves)

Here's a sample set where I just spam triggered and none failed

![spam-click](https://github.com/jdc-cunningham/modular-pi-cam/assets/11015467/79f3dc6e-567b-4cee-9b63-2b9909d717b1)

As a bonus to this PR a photo from today

![v3-stand2](https://github.com/jdc-cunningham/modular-pi-cam/assets/11015467/90ea7de4-98a6-4676-9771-72a363b3d4f1)

Taken with v3 standard