### PR TITLE
Feat: add manual battery reset

### DIFF
--- a/cameras/pi-zero/large-display/software/display/display.py
+++ b/cameras/pi-zero/large-display/software/display/display.py
@@ -254,7 +254,8 @@ class Display:
     draw.text((5, 0), "Settings", fill = "WHITE", font = large_font)
     draw.text((5, 26), "Telemetry", fill = "BLACK", font = large_font)
     draw.text((5, 52), "Battery Profiler", fill = "BLACK", font = large_font)
-    draw.text((5, 78), "Timelapse", fill = "BLACK", font = large_font)
+    draw.text((5, 78), "Reset Battery", fill = "BLACK", font = large_font)
+    draw.text((5, 104), "Timelapse", fill = "BLACK", font = large_font)
 
     return image
   
@@ -295,7 +296,7 @@ class Display:
     image = self.get_settings_img()
     draw = ImageDraw.Draw(image)
 
-    draw.line([(0, 26), (0, 42)], fill = "BLUE", width = 2)
+    draw.line([(0, 26), (0, 42)], fill = "BLUE", width = 2) # 16 tall, 10 y apart
 
     self.disp.ShowImage(self.match_lcd(image))
 
@@ -307,11 +308,19 @@ class Display:
 
     self.disp.ShowImage(self.match_lcd(image))
 
-  def draw_active_timelapse(self):
+  def draw_active_reset_battery(self):
     image = self.get_settings_img()
     draw = ImageDraw.Draw(image)
 
     draw.line([(0, 78), (0, 94)], fill = "BLUE", width = 2)
+
+    self.disp.ShowImage(self.match_lcd(image))
+
+  def draw_active_timelapse(self):
+    image = self.get_settings_img()
+    draw = ImageDraw.Draw(image)
+
+    draw.line([(0, 104), (0, 120)], fill = "BLUE", width = 2)
 
     self.disp.ShowImage(self.match_lcd(image))
 

--- a/cameras/pi-zero/large-display/software/menu/menu.py
+++ b/cameras/pi-zero/large-display/software/menu/menu.py
@@ -32,7 +32,7 @@ class Menu:
         self.menu_y += 1
 
     if (self.main.active_menu == "Settings"):
-      if (button_pressed == "DOWN" and self.menu_settings_y < 3):
+      if (button_pressed == "DOWN" and self.menu_settings_y < 4):
         self.menu_settings_y += 1
       
       if (button_pressed == "UP" and self.menu_settings_y > 1):
@@ -50,22 +50,21 @@ class Menu:
       if (button_pressed == "CENTER"):
         if (self.active_menu_item == "Telemetry"):
           self.display.render_telemetry_page()
-          self.main.processing = False
-          return
     
         if (self.active_menu_item == "Battery Profiler"):
           self.display.render_battery_profiler()
           self.main.battery.start_profiler()
           self.main.battery_profiler_active = True
-          self.main.processing = False
-          return
+        
+        if (self.active_menu_item == "Reset Battery"):
+          self.main.battery.reset_uptime()
       
         if (self.active_menu_item == "Timelapse"):
           self.main.active_menu = "Timelapse"
           self.display.render_timelapse()
           self.main.camera.start_timelapse()
-          self.main.processing = False
-          return
+
+        self.main.processing = False
 
     self.update_menu(button_pressed)
 
@@ -116,6 +115,11 @@ class Menu:
 
       if (self.menu_settings_y == 3):
         self.display.render_settings()
+        self.display.draw_active_reset_battery()
+        self.active_menu_item = "Reset Battery"
+
+      if (self.menu_settings_y == 4):
+        self.display.render_settings()
         self.display.draw_active_timelapse()
         self.active_menu_item = "Timelapse"
 
@@ -149,6 +153,11 @@ class Menu:
         self.main.battery.stop_profiler()
         self.main.active_menu = "Home"
         self.main.battery_profiler_active = False
+        self.display.start_menu()
+    
+    if (self.main.active_menu == "Reset Battery"):
+      if (button == "BACK"):
+        self.main.active_menu = "Home"
         self.display.start_menu()
 
     if (self.main.active_menu == "Timelapse"):


### PR DESCRIPTION
Allows you to manually reset the battery uptime if you want to charge the camera before being prompted with the "charged?" question.