### PR TITLE
Feat: multi video background processing and processing message (with mic)

### DIFF
--- a/cameras/pi-zero/large-display/software/camera/camera.py
+++ b/cameras/pi-zero/large-display/software/camera/camera.py
@@ -32,7 +32,7 @@ class Camera:
     self.encoder = H264Encoder(30000000, repeat=True)
     self.encoder.output = CircularOutput(buffersize = 150)
     self.video_filename = ""
-    self.video_processing = False
+    self.video_processing = []
 
     self.which_camera()
 
@@ -116,7 +116,7 @@ class Camera:
     self.encoder.output.fileoutput = video_file_path
     self.encoder.output.start()
 
-    while (self.main.menu.recording_video and (not self.video_processing)):
+    while (self.main.menu.recording_video):
       cap = self.picam2.capture_array("lores")
       self.sample_video(cap)
       time.sleep(0.03)
@@ -136,7 +136,7 @@ class Camera:
       Thread(target=self.record_video).start()
 
   def stop_video_recording(self):
-    self.video_processing = True
+    self.video_processing.append(self.video_filename)
 
     if (self.main.mic != None):
       self.main.mic.recording = False
@@ -155,7 +155,7 @@ class Camera:
       os.system(cmd)
       self.main.display.draw_text("Recording saved")
       self.main.menu.recording_video = False
-      self.video_processing = False
+      self.video_processing.remove(self.video_filename)
       time.sleep(2)
       self.main.active_menu = "Home"
       self.main.display.start_menu()

--- a/cameras/pi-zero/large-display/software/camera/camera.py
+++ b/cameras/pi-zero/large-display/software/camera/camera.py
@@ -93,7 +93,7 @@ class Camera:
     self.config_1x = self.picam2.create_still_configuration(main={"size": (320, 320)}) # 320 is based on display size
     self.config_3x = self.picam2.create_still_configuration(main={"size": (960, 960)}) # x3 so a step in either direction
     self.config_7x = self.picam2.create_still_configuration(main={"size": (2240, 2240)}) # x7
-    self.video_config = self.picam2.create_video_configuration(main={"size": (1920, 1080), "format":"RGB888"}, lores={"size": (400, 400), "format": "YUV420"})
+    self.video_config = self.picam2.create_video_configuration(main={"size": (1920, 1080), "format":"RGB888"}, lores={"size": (320, 320), "format": "YUV420"})
     self.picam2.configure(self.config_1x)
     self.start()
 
@@ -124,6 +124,9 @@ class Camera:
   def start_video_recording(self):
       self.video_filename = str(time.time()).split(".")[0] + ".h264"
       self.video_processing.append(self.video_filename)
+      print('>>> appended')
+      print(self.video_filename)
+      print(self.video_processing)
       self.change_mode("video")
       self.recording_time = time.time()
       self.picam2.start_encoder(self.encoder)
@@ -153,10 +156,11 @@ class Camera:
       cmd += ' -c copy ' + self.img_base_path + self.video_filename + '.mp4'
       os.system(cmd)
       self.main.menu.recording_video = False
-      self.video_processing.remove(self.video_filename)
       print(self.video_processing)
       print('>>> cam remove')
       print(self.video_filename)
+      self.video_processing.remove(self.video_filename)
+      self.video_filename = ""
       time.sleep(2)
       self.main.active_menu = "Home"
       self.main.display.start_menu()

--- a/cameras/pi-zero/large-display/software/camera/camera.py
+++ b/cameras/pi-zero/large-display/software/camera/camera.py
@@ -124,11 +124,6 @@ class Camera:
 
   def start_video_recording(self, video_filename):
       self.video_processing.append(video_filename)
-      print('')
-      print('>>> appended')
-      print(video_filename)
-      print(self.video_processing)
-      print('')
       self.change_mode("video")
       self.recording_time = time.time()
       self.picam2.start_encoder(self.encoder)
@@ -157,11 +152,6 @@ class Camera:
       cmd = 'ffmpeg -framerate 30 -i ' + self.img_base_path + video_filename
       cmd += ' -c copy ' + self.img_base_path + self.video_filename + '.mp4'
       os.system(cmd)
-      print('')
-      print(self.video_processing)
-      print('>>> cam remove')
-      print(video_filename)
-      print('')
       self.video_processing.remove(video_filename)
 
       if (self.main.active_menu != "Video"):

--- a/cameras/pi-zero/large-display/software/camera/camera.py
+++ b/cameras/pi-zero/large-display/software/camera/camera.py
@@ -123,6 +123,7 @@ class Camera:
 
   def start_video_recording(self):
       self.video_filename = str(time.time()).split(".")[0] + ".h264"
+      self.video_processing.append(self.video_filename)
       self.change_mode("video")
       self.recording_time = time.time()
       self.picam2.start_encoder(self.encoder)
@@ -136,8 +137,6 @@ class Camera:
       Thread(target=self.record_video).start()
 
   def stop_video_recording(self):
-    self.video_processing.append(self.video_filename)
-
     if (self.main.mic != None):
       self.main.mic.recording = False
 
@@ -153,9 +152,11 @@ class Camera:
       cmd = 'ffmpeg -framerate 30 -i ' + self.img_base_path + self.video_filename
       cmd += ' -c copy ' + self.img_base_path + self.video_filename + '.mp4'
       os.system(cmd)
-      self.main.display.draw_text("Recording saved")
       self.main.menu.recording_video = False
       self.video_processing.remove(self.video_filename)
+      print(self.video_processing)
+      print('>>> cam remove')
+      print(self.video_filename)
       time.sleep(2)
       self.main.active_menu = "Home"
       self.main.display.start_menu()

--- a/cameras/pi-zero/large-display/software/camera/camera.py
+++ b/cameras/pi-zero/large-display/software/camera/camera.py
@@ -111,7 +111,8 @@ class Camera:
     pil_img = Image.fromarray(np.uint8(rgb_img2))
     self.display.show_image(pil_img, "video")
 
-  def record_video(self):
+  def record_video(self, filename):
+    self.video_filename = filename
     video_file_path =  self.img_base_path + self.video_filename
     self.encoder.output.fileoutput = video_file_path
     self.encoder.output.start()
@@ -121,12 +122,13 @@ class Camera:
       self.sample_video(cap)
       time.sleep(0.03)
 
-  def start_video_recording(self):
-      self.video_filename = str(time.time()).split(".")[0] + ".h264"
-      self.video_processing.append(self.video_filename)
+  def start_video_recording(self, video_filename):
+      self.video_processing.append(video_filename)
+      print('')
       print('>>> appended')
-      print(self.video_filename)
+      print(video_filename)
       print(self.video_processing)
+      print('')
       self.change_mode("video")
       self.recording_time = time.time()
       self.picam2.start_encoder(self.encoder)
@@ -135,11 +137,11 @@ class Camera:
       # the mic is assumed to always be plugged in or not
       # since plugging it back in turns off the pi
       if (self.main.usb.mic_available):
-        self.main.mic.record(self.img_base_path + self.video_filename)
+        self.main.mic.record(self.img_base_path + video_filename)
 
-      Thread(target=self.record_video).start()
+      Thread(target=self.record_video, args=(video_filename,)).start()
 
-  def stop_video_recording(self):
+  def stop_video_recording(self, video_filename):
     if (self.main.mic != None):
       self.main.mic.recording = False
 
@@ -152,18 +154,19 @@ class Camera:
     # can set it as another thread or don't do it
 
     if (self.main.mic == None):
-      cmd = 'ffmpeg -framerate 30 -i ' + self.img_base_path + self.video_filename
+      cmd = 'ffmpeg -framerate 30 -i ' + self.img_base_path + video_filename
       cmd += ' -c copy ' + self.img_base_path + self.video_filename + '.mp4'
       os.system(cmd)
-      self.main.menu.recording_video = False
+      print('')
       print(self.video_processing)
       print('>>> cam remove')
-      print(self.video_filename)
-      self.video_processing.remove(self.video_filename)
-      self.video_filename = ""
-      time.sleep(2)
-      self.main.active_menu = "Home"
-      self.main.display.start_menu()
+      print(video_filename)
+      print('')
+      self.video_processing.remove(video_filename)
+
+      if (self.main.active_menu != "Video"):
+        self.main.active_menu = "Home"
+        self.main.display.start_menu()
 
   def change_mode(self, mode):
     self.last_mode = mode

--- a/cameras/pi-zero/large-display/software/display/display.py
+++ b/cameras/pi-zero/large-display/software/display/display.py
@@ -9,7 +9,7 @@ base_path = os.getcwd()
 sys.path.append(base_path + "/display/")
 
 from lib import LCD_2inch4
-from PIL import Image,ImageDraw,ImageFont
+from PIL import Image, ImageDraw, ImageFont
 from threading import Thread
 
 RST = 27
@@ -112,6 +112,11 @@ class Display:
     # draw.text((7, 90), "S: 1/60", fill = "WHITE", font = small_font)
     # draw.text((7, 105), "E: 100", fill = "WHITE", font = small_font)
     draw.text((22, 48), center_text, fill = "BLACK", font = large_font)
+    processing_text = len(self.main.camera.video_processing) > 0
+
+    if (processing_text):
+      draw.text((22, 60), "video processing", fill = "BLACK", font = small_font)
+
     draw.text((58, 3), self.main.battery.get_remaining_time(), fill = "BLACK", font = small_font)
 
     file_count = self.utils.get_file_count()

--- a/cameras/pi-zero/large-display/software/menu/menu.py
+++ b/cameras/pi-zero/large-display/software/menu/menu.py
@@ -208,8 +208,6 @@ class Menu:
         else:
           if (not self.main.camera.video_processing):
             self.camera.stop_video_recording()
-          else:
-            self.main.display.draw_text("Video processing")
 
           time.sleep(1)
           self.main.active_menu = "Home"

--- a/cameras/pi-zero/large-display/software/menu/menu.py
+++ b/cameras/pi-zero/large-display/software/menu/menu.py
@@ -17,6 +17,7 @@ class Menu:
     self.battery_charged = False # yes, no question
     self.menu_daf_x = 1 # delete all files (no)
     self.menu_txfer_x = 1 # transfer usb (cancel)
+    self.video_filename = ""
 
   def update_state(self, button_pressed):
     if (self.main.active_menu == "Home"):
@@ -203,13 +204,14 @@ class Menu:
       if (button == "SHUTTER"):
         if (not self.recording_video):
           self.display.clear_screen()
-          self.camera.start_video_recording()
+          self.video_filename = str(time.time()).split(".")[0] + ".h264"
+          self.camera.start_video_recording(self.video_filename)
           self.recording_video = True
         else:
-          self.recording_video = False
-          self.camera.stop_video_recording()
-
+          self.camera.stop_video_recording(self.video_filename)
           time.sleep(1)
+          self.recording_video = False
+          self.video_filename = ""
           self.main.active_menu = "Home"
           self.main.display.start_menu()
 

--- a/cameras/pi-zero/large-display/software/menu/menu.py
+++ b/cameras/pi-zero/large-display/software/menu/menu.py
@@ -206,8 +206,8 @@ class Menu:
           self.camera.start_video_recording()
           self.recording_video = True
         else:
-          if (not self.main.camera.video_processing):
-            self.camera.stop_video_recording()
+          self.recording_video = False
+          self.camera.stop_video_recording()
 
           time.sleep(1)
           self.main.active_menu = "Home"

--- a/cameras/pi-zero/large-display/software/microphone/microphone.py
+++ b/cameras/pi-zero/large-display/software/microphone/microphone.py
@@ -127,7 +127,7 @@ class Microphone:
       self.chunk_id = 0
       self.main.display.draw_text("Recording saved")
       self.main.menu.recording_video = False
-      self.main.camera.video_processing = False
+      self.main.camera.video_processing.remove(self.filename)
       time.sleep(2)
       self.main.active_menu = "Home"
       self.main.display.start_menu()

--- a/cameras/pi-zero/large-display/software/microphone/microphone.py
+++ b/cameras/pi-zero/large-display/software/microphone/microphone.py
@@ -125,9 +125,11 @@ class Microphone:
 
       self.filename = ""
       self.chunk_id = 0
-      self.main.display.draw_text("Recording saved")
       self.main.menu.recording_video = False
       self.main.camera.video_processing.remove(self.filename)
+      print(self.main.camera.video_processing)
+      print('>>> remove mic')
+      print(self.filename)
       time.sleep(2)
       self.main.active_menu = "Home"
       self.main.display.start_menu()

--- a/cameras/pi-zero/large-display/software/microphone/microphone.py
+++ b/cameras/pi-zero/large-display/software/microphone/microphone.py
@@ -33,7 +33,7 @@ class Microphone:
 
   def record(self, filename):
     self.filename = filename
-    Thread(target=self.start_recording).start()
+    Thread(target=self.start_recording, args=(filename.split('/captured-media/')[1],)).start()
 
   def get_audio_files(self, filename):
     base_name = filename.split('.h264')[0].split('/captured-media/')[1]
@@ -76,7 +76,9 @@ class Microphone:
     cmd += " -map '[out]' " + filename + '.wav'
     os.system(cmd)
 
-  def start_recording(self):
+  def start_recording(self, filename):
+    print('>>> what')
+    print(filename)
 
     self.recording = True
     self.record_frames = []
@@ -93,9 +95,9 @@ class Microphone:
       if (not self.main.mic.recording):
         break
 
-    self.stop_recording()
+    self.stop_recording(filename)
 
-  def stop_recording(self):
+  def stop_recording(self, filename):
     self.stream.stop_stream()
     self.stream.close()
 
@@ -123,13 +125,13 @@ class Microphone:
       cmd = 'ffmpeg -i ' + self.filename + '.mp4' + ' -i ' + self.filename + '.wav' + ' -c:v copy -c:a aac ' + self.filename  + '-wsound' + '.mp4'
       os.system(cmd)
 
-      self.filename = ""
       self.chunk_id = 0
       self.main.menu.recording_video = False
-      self.main.camera.video_processing.remove(self.filename)
       print(self.main.camera.video_processing)
       print('>>> remove mic')
-      print(self.filename)
+      print(filename)
+      self.main.camera.video_processing.remove(filename)
+      self.filename = ""
       time.sleep(2)
       self.main.active_menu = "Home"
       self.main.display.start_menu()

--- a/cameras/pi-zero/large-display/software/microphone/microphone.py
+++ b/cameras/pi-zero/large-display/software/microphone/microphone.py
@@ -31,17 +31,9 @@ class Microphone:
         self.device_id = i
 
   def record(self, filename):
-    print('')
-    print('>>> pased into record')
-    print(filename)
-    print('')
     Thread(target=self.start_recording, args=(filename.split('/captured-media/')[1],)).start()
 
   def get_audio_files(self, filename):
-    print('')
-    print('>>> get audio files')
-    print(filename)
-    print('')
     base_name = filename.split('.h264')[0]
     base_path = os.getcwd()
     capture_path = base_path + "/captured-media/"
@@ -73,10 +65,6 @@ class Microphone:
 
     base_path = os.getcwd() + '/captured-media/'
     audio_files = self.get_audio_files(filename)
-    print('')
-    print('>>> audio files')
-    print(audio_files)
-    print('')
     cmd = 'ffmpeg'
 
     for audio_file in audio_files['files']:
@@ -87,11 +75,6 @@ class Microphone:
     os.system(cmd)
 
   def start_recording(self, filename):
-    print('')
-    print('>>> what')
-    print(filename)
-    print('')
-
     self.recording = True
     self.record_frames = []
 
@@ -110,9 +93,6 @@ class Microphone:
     self.stop_recording(filename)
 
   def stop_recording(self, filename):
-    print('')
-    print('>>> stop recording')
-    print('')
     self.stream.stop_stream()
     self.stream.close()
 
@@ -143,11 +123,6 @@ class Microphone:
       os.system(cmd)
 
       self.chunk_id = 0
-      print('')
-      print(self.main.camera.video_processing)
-      print('>>> remove mic')
-      print(filename)
-      print('')
       self.main.camera.video_processing.remove(filename)
 
       if (self.main.active_menu != "Video"):


### PR DESCRIPTION
When a video is recorded:

* `.wav` file(s) are recorded by a USB mic if available
* a `.h264` video file is recorded
* the multiple `.wav` files are concatenated into 1 (ffmpeg)
* `.h264` file converted to `.mp4` (ffmpeg)
* `.mp4` and `.wav` combined into single `.mp4` file called `<filename>-wsound.mp4`

This processes used to be single threaded mostly because the way I used to record audio was using a lot of calls/terminating the `pyaudio` instance which would lead to a segfault/systemd service would restart.

Now a user can keep recording many videos while others process in the background doing the steps above. It uses threads and `os.system` calls in those threads.

An array of time-stamp based filenames are kept track as the videos are recorded/processed.

Doing a quick check without the USB mic the video is frozen until the file is processed then goes back to menu... there it is forced to do 1 thing at a time, don't know why from a quick glance however the slowest video processing is with audio since it has to merge audio files and then merge video with audio.
